### PR TITLE
Cache key error

### DIFF
--- a/shared/client/message.go
+++ b/shared/client/message.go
@@ -172,11 +172,8 @@ func (m *Message) StringsKey(key string, values []string) {
 			m.multiKeys[i][index] = keyValue
 		}
 	}
-	if index <= 0 {
-		return
-	}
 
-	m.expendKeysIfNeeded(len(values), index, keyValue)
+	m.expandKeysIfNeeds(len(values), index, keyValue)
 
 }
 
@@ -192,25 +189,30 @@ func (m *Message) IntsKey(key string, values []int) {
 		if len(m.multiKeys[i]) == 0 {
 			m.multiKeys[i] = make([]string, m.dictionary.inputSize())
 		}
+
 		if intKeyValue, index = m.dictionary.lookupInt(key, value); index != unknownKeyField {
 			keyValue = strconv.Itoa(intKeyValue)
 			m.multiKeys[i][index] = keyValue
 		}
 	}
-	m.expendKeysIfNeeded(len(values), index, keyValue)
+
+	m.expandKeysIfNeeds(len(values), index, keyValue)
 }
 
-func (m *Message) expendKeysIfNeeded(valuesLen int, index int, keyValue string) {
+func (m *Message) expandKeysIfNeeds(valuesLen int, index int, keyValue string) {
 	if index < 0 {
 		return
 	}
+
 	if valuesLen > 1 || m.batchSize <= 1 {
 		return
 	}
+
 	for i := 1; i < m.batchSize; i++ {
 		if len(m.multiKeys[i]) == 0 {
 			m.multiKeys[i] = make([]string, m.dictionary.inputSize())
 		}
+
 		m.multiKeys[i][index] = keyValue
 	}
 }
@@ -261,7 +263,7 @@ func (m *Message) FloatsKey(key string, values []float32) {
 			m.multiKeys[i][index] = keyValue
 		}
 	}
-	m.expendKeysIfNeeded(len(values), index, keyValue)
+	m.expandKeysIfNeeds(len(values), index, keyValue)
 }
 
 // FloatsKey sets key/values pair
@@ -396,12 +398,15 @@ func (m *Message) CacheKeyAt(index int) string {
 	if m.batchSize == 0 {
 		return m.CacheKey()
 	}
+
 	if len(m.multiKey) == 0 {
 		m.multiKey = make([]string, len(m.multiKeys))
 	}
+
 	if m.multiKey[index] != "" {
 		return m.multiKey[index]
 	}
+
 	m.multiKey[index] = buildKey(m.multiKeys[index], m.buffer)
 	m.buffer.Reset()
 	return m.multiKey[index]

--- a/shared/client/message_test.go
+++ b/shared/client/message_test.go
@@ -17,7 +17,7 @@ func TestMessage(t *testing.T) {
 			},
 			common.Layer{
 				Name:    "multi",
-				Strings: []string{"a", "b", "c"},
+				Strings: []string{"a", "b"},
 			},
 		},
 		Hash: 1,
@@ -45,18 +45,15 @@ func TestMessage(t *testing.T) {
 	msgs := NewMessages(makeDict)
 	msg := msgs.Borrow()
 
-	msg.SetBatchSize(3)
+	msg.SetBatchSize(2)
 
-	msg.StringsKey("multi", []string{"a", "b", "c"})
+	msg.StringsKey("multi", []string{"a", "b"})
 	msg.StringsKey("copied", []string{"1"})
 
 	var key string
 	key = msg.CacheKeyAt(0)
-	assert.Equal(t, "1/a", key)
+	assert.Equal(t, "[UNK]/a", key)
 
 	key = msg.CacheKeyAt(1)
-	assert.Equal(t, "1/b", key)
-
-	key = msg.CacheKeyAt(2)
-	assert.Equal(t, "1/c", key)
+	assert.Equal(t, "[UNK]/b", key)
 }

--- a/shared/client/message_test.go
+++ b/shared/client/message_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/viant/mly/shared"
+	"github.com/viant/mly/shared/common"
+)
+
+func TestMessage(t *testing.T) {
+	commonDict := &common.Dictionary{
+		Layers: []common.Layer{
+			common.Layer{
+				Name:    "copied",
+				Strings: []string{},
+			},
+			common.Layer{
+				Name:    "multi",
+				Strings: []string{"a", "b", "c"},
+			},
+		},
+		Hash: 1,
+	}
+
+	inputs := []*shared.Field{
+		&shared.Field{
+			Name:     "copied",
+			Index:    0,
+			DataType: "string",
+			//Wildcard: true,
+		},
+		&shared.Field{
+			Name:     "multi",
+			Index:    1,
+			DataType: "string",
+		},
+	}
+
+	makeDict := func() *Dictionary {
+		dict := NewDictionary(commonDict, inputs)
+		return dict
+	}
+
+	msgs := NewMessages(makeDict)
+	msg := msgs.Borrow()
+
+	msg.SetBatchSize(3)
+
+	msg.StringsKey("multi", []string{"a", "b", "c"})
+	msg.StringsKey("copied", []string{"1"})
+
+	var key string
+	key = msg.CacheKeyAt(0)
+	assert.Equal(t, "1/a", key)
+
+	key = msg.CacheKeyAt(1)
+	assert.Equal(t, "1/b", key)
+
+	key = msg.CacheKeyAt(2)
+	assert.Equal(t, "1/c", key)
+}


### PR DESCRIPTION
Addresses #6.

Caused by unexplained `index <= 0` check.