### PR TITLE
Add singleflight for Aerospike puts.

### DIFF
--- a/shared/datastore/client/aero.go
+++ b/shared/datastore/client/aero.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	aero "github.com/aerospike/aerospike-client-go"
+)
+
+// Aero is a mock of aerospike.Client.
+type Aero interface {
+	// Mocks aerospike.Client.Get
+	Get(policy *aero.BasePolicy, key *aero.Key, binNames ...string) (record *aero.Record, err error)
+
+	// Mocks aerospike.Client.Put
+	Put(writePolicy *aero.WritePolicy, key *aero.Key, value aero.BinMap) (err error)
+}
+
+// keyString avoids using Key.String() to avoid inner usages of fmt.Sprintf
+/*
+goos: darwin
+goarch: arm64
+pkg: github.com/viant/mly/shared/datastore/client
+cpu: Apple M3 Max
+BenchmarkKeyString-16           32234271                31.74 ns/op
+BenchmarkKeyStringer-16           986280              1229 ns/op
+*/
+func keyString(key *aero.Key) string {
+	if key.Value() == nil {
+		return key.Namespace() + "." + key.SetName()
+	}
+
+	// key.Value().String() may contain inner usages of fmt.Sprintf
+	return key.Namespace() + "." + key.SetName() + "." + key.Value().String()
+}

--- a/shared/datastore/client/aero_test.go
+++ b/shared/datastore/client/aero_test.go
@@ -1,0 +1,23 @@
+package client
+
+import (
+	"testing"
+
+	aero "github.com/aerospike/aerospike-client-go"
+)
+
+func BenchmarkKeyString(b *testing.B) {
+	key, _ := aero.NewKey("test", "test", "test")
+	strs := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		strs[i] = keyString(key)
+	}
+}
+
+func BenchmarkKeyStringer(b *testing.B) {
+	key, _ := aero.NewKey("test", "test", "test")
+	strs := make([]string, b.N)
+	for i := 0; i < b.N; i++ {
+		strs[i] = key.String()
+	}
+}

--- a/shared/datastore/client/service.go
+++ b/shared/datastore/client/service.go
@@ -10,11 +10,23 @@ import (
 	"github.com/viant/mly/shared/circut"
 	"github.com/viant/mly/shared/common"
 	"github.com/viant/mly/shared/config/datastore"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	// DefaultPutSingleflightTimeout is based off default value for BasePolicy.SocketTimeout
+	// Since retries are not recommended for Put operations, we will use this simple value
+	DefaultPutSingleflightTimeout = time.Second * 30
+
+	// This might be too short for a pure default configuration.
+	// It looks like it should be something like SocketTimeout + SleepBetweenRetries * cumulative product from 1 to MaxRetries of SleepMultiplier...
+	// But in our common use case, 30 seconds is very long, and the Aerospike Client should timeout first.
+	DefaultGetSingleflightTimeout = time.Second * 30
 )
 
 // Service represents aerospike client Service
 type Service struct {
-	*aero.Client
+	Client Aero
 
 	config *datastore.Connection
 
@@ -22,12 +34,16 @@ type Service struct {
 	bypassConfiguredTimeout bool
 
 	// basePolicy can be overridden by WithBasePolicy.
+	// basePolicy is only used for Get operations.
 	// Even when overridden, the timeout will be applied UNLESS using WithBypassConfiguredTimeout.
 	basePolicy *aero.BasePolicy
 
 	// clientPolicy can be overridden by WithClientPolicy.
 	// Even when overridden, the timeout will be applied UNLESS using WithBypassConfiguredTimeout.
 	clientPolicy *aero.ClientPolicy
+
+	// group is used to dedupe concurrent puts
+	group *singleflight.Group
 
 	*circut.Breaker
 }
@@ -37,11 +53,14 @@ func (s *Service) Get(ctx context.Context, key *aero.Key, binNames ...string) (r
 	if !s.IsUp() {
 		return nil, common.ErrNodeDown
 	}
+
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("failed to read data from aersopike: panic: %v", r)
+			connection := s.config.ID
+			err = fmt.Errorf("get aerospike[%s]: panic: %v", connection, r)
 		}
 	}()
+
 	record, err = s.Client.Get(s.basePolicy, key, binNames...)
 	s.checkConnectionError(err)
 	return record, err
@@ -49,13 +68,49 @@ func (s *Service) Get(ctx context.Context, key *aero.Key, binNames ...string) (r
 
 // Put puts a record to Aerospike.
 // Context is not supported since the Aerospike library does not support it.
-func (s *Service) Put(writePolicy *aero.WritePolicy, key *aero.Key, value aero.BinMap) error {
+func (s *Service) Put(writePolicy *aero.WritePolicy, key *aero.Key, value aero.BinMap) (err error) {
 	if !s.IsUp() {
 		return common.ErrNodeDown
 	}
 
-	err := s.Client.Put(writePolicy, key, value)
-	s.checkConnectionError(err)
+	if writePolicy == nil {
+		writePolicy = aero.NewWritePolicy(0, 0)
+	}
+
+	keyStr := keyString(key)
+
+	defer func() {
+		if r := recover(); r != nil {
+			connection := s.config.ID
+			err = fmt.Errorf("put aerospike[%s] key: %s panic: %v", connection, keyStr, r)
+		}
+	}()
+
+	var timeout time.Duration
+	if writePolicy.TotalTimeout > 0 {
+		timeout = time.Millisecond * writePolicy.TotalTimeout
+	} else {
+		timeout = DefaultPutSingleflightTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	ch := s.group.DoChan(keyStr, func() (interface{}, error) {
+		err := s.Client.Put(writePolicy, key, value)
+		s.checkConnectionError(err)
+		return nil, err
+	})
+
+	select {
+	case <-ctx.Done():
+		err = fmt.Errorf("put aerospike[%s] key: %s singleflight: %w", s.config.ID, keyStr, ctx.Err())
+	case res := <-ch:
+		if res.Err != nil {
+			err = fmt.Errorf("put aerospike[%s] key: %s error: %w", s.config.ID, keyStr, res.Err)
+		}
+	}
+
 	return err
 }
 
@@ -136,7 +191,9 @@ func New(config *datastore.Connection) (*Service, error) {
 func NewWithOptions(config *datastore.Connection, options ...Option) (*Service, error) {
 	srv := &Service{
 		config: config,
+		group:  new(singleflight.Group),
 	}
+
 	srv.init(options...)
 	breaker := circut.New(time.Second, srv)
 	srv.Breaker = breaker

--- a/shared/datastore/client/service_test.go
+++ b/shared/datastore/client/service_test.go
@@ -1,0 +1,93 @@
+package client
+
+import (
+	"log"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	aero "github.com/aerospike/aerospike-client-go"
+	"github.com/viant/mly/shared/circut"
+	"golang.org/x/sync/singleflight"
+)
+
+type MockAero struct {
+	counter uint64
+
+	L *sync.RWMutex
+}
+
+func (m *MockAero) Get(policy *aero.BasePolicy, key *aero.Key, binNames ...string) (record *aero.Record, err error) {
+	return nil, nil
+}
+
+func (m *MockAero) Put(writePolicy *aero.WritePolicy, key *aero.Key, value aero.BinMap) (err error) {
+	log.Printf("wait lock %d", m.counter)
+	m.L.RLock()
+	defer m.L.RUnlock()
+	log.Printf("put %d", m.counter)
+	atomic.AddUint64(&m.counter, 1)
+	return nil
+}
+
+func TestPut(t *testing.T) {
+	mockLock := new(sync.RWMutex)
+	mockAero := &MockAero{
+		L: mockLock,
+	}
+
+	service := &Service{
+		Client: mockAero,
+		group:  new(singleflight.Group),
+		basePolicy: &aero.BasePolicy{
+			TotalTimeout: 15 * time.Second,
+		},
+	}
+
+	breaker := circut.New(time.Second, service)
+	service.Breaker = breaker
+
+	key, _ := aero.NewKey("test", "test", "test")
+	policy := aero.NewWritePolicy(0, 0)
+
+	var finishGroup, startGroup sync.WaitGroup
+
+	totalPuts := 20
+	finishGroup.Add(totalPuts)
+	startGroup.Add(totalPuts)
+
+	// prevent put from completing
+	mockLock.Lock()
+
+	for i := 0; i < totalPuts; i++ {
+		go func() {
+			defer finishGroup.Done()
+			log.Printf("start %d", i)
+			startGroup.Done()
+			err := service.Put(policy, key, aero.BinMap{"test": "test"})
+			log.Printf("done %d, err: %v", i, err)
+		}()
+	}
+
+	startGroup.Wait()
+	mockLock.Unlock()
+	finishGroup.Wait()
+
+	if mockAero.counter != 1 {
+		t.Fatalf("expected 1 put, got %d", mockAero.counter)
+	}
+
+	// run without any blocking
+	finishGroup.Add(totalPuts)
+	for i := 0; i < totalPuts; i++ {
+		go func() {
+			defer finishGroup.Done()
+			err := service.Put(policy, key, aero.BinMap{"test": "test"})
+			log.Printf("done %d, err: %v", i, err)
+		}()
+	}
+	finishGroup.Wait()
+
+	log.Printf("put total counter: %d (max %d)", mockAero.counter, totalPuts)
+}


### PR DESCRIPTION
- Mock Aerospike Client
- Add singleflight usage with context timeout using DoChan
- Add Benchmark for not using aerospike.Key.String()

New target branch `v0.18.x` (replacing https://github.com/viant/mly/pull/47)