### PR TITLE
feat(router): support global-only routing with empty entityMapping

### DIFF
--- a/service/platform/router/reload.go
+++ b/service/platform/router/reload.go
@@ -248,21 +248,16 @@ func (r *Router) applyRouterConfig(ctx context.Context, newConfig *router.Routin
 	signatureCh := make(chan modelSignature, numWorkers)
 
 	if globalEvaluator != nil {
-		// With an empty entity routing table (a global-only config), no entity
-		// model contributes a signature, so the global model must seed the
-		// router's IO signature; otherwise the router would have no signature
-		// and fail (nil signature, or a fixed-evaluator field check against no
-		// outputs). When entity models exist, they seed the signature instead.
-		globalSeedsSignature := len(newRoutingTable) == 0
+		// The global model is a served model, so its signature always takes part
+		// in building and validating the router IO. This also covers a global-only
+		// config (empty entityMapping): without it the router would have no
+		// signature and fail on cold start (nil signature, or a fixed-evaluator
+		// field check against no collected outputs).
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			if err := globalEvaluator.ReloadIfNeeded(ctx); err != nil {
 				errCh <- fmt.Errorf("failed to reload global model %s: %w", globalModelName, err)
-				return
-			}
-
-			if !globalSeedsSignature {
 				return
 			}
 

--- a/service/platform/router/reload.go
+++ b/service/platform/router/reload.go
@@ -248,11 +248,33 @@ func (r *Router) applyRouterConfig(ctx context.Context, newConfig *router.Routin
 	signatureCh := make(chan modelSignature, numWorkers)
 
 	if globalEvaluator != nil {
+		// With an empty entity routing table (a global-only config), no entity
+		// model contributes a signature, so the global model must seed the
+		// router's IO signature; otherwise the router would have no signature
+		// and fail (nil signature, or a fixed-evaluator field check against no
+		// outputs). When entity models exist, they seed the signature instead.
+		globalSeedsSignature := len(newRoutingTable) == 0
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			if err := globalEvaluator.ReloadIfNeeded(ctx); err != nil {
 				errCh <- fmt.Errorf("failed to reload global model %s: %w", globalModelName, err)
+				return
+			}
+
+			if !globalSeedsSignature {
+				return
+			}
+
+			evalSig := globalEvaluator.Signature()
+			if evalSig == nil {
+				errCh <- fmt.Errorf("global model %s signature is nil", globalModelName)
+				return
+			}
+
+			signatureCh <- modelSignature{
+				name:      globalModelName,
+				signature: evalSig,
 			}
 		}()
 	}

--- a/service/platform/router/reload_test.go
+++ b/service/platform/router/reload_test.go
@@ -175,6 +175,68 @@ func TestRouter_applyRouterConfig_LoadsAndSwaps(t *testing.T) {
 	}
 }
 
+// TestRouter_applyRouterConfig_GlobalOnly guards support for a global-only
+// routing config (an empty entityMapping with only a globalModelName). Without
+// the global model seeding the router signature, applyRouterConfig leaves a nil
+// IO signature, which later causes runtime panics (nil signature deref) or
+// fails the fixed-evaluator field check against no collected outputs.
+func TestRouter_applyRouterConfig_GlobalOnly(t *testing.T) {
+	ctx := context.Background()
+
+	makeSig := func() *domain.Signature {
+		return &domain.Signature{
+			Inputs: []domain.Input{
+				{Name: "text", Index: 0, Type: reflect.TypeOf("")},
+			},
+			Outputs: []domain.Output{
+				{Name: "score", Index: 0, DataType: "float32"},
+			},
+		}
+	}
+
+	router := &Router{
+		debug:                true,
+		routerName:           "global_only",
+		routerInputFieldName: "entity_id",
+		unloader:             &triton.Service{Unloader: &mockUnloader{}, Repository: triton.NewRepository()},
+		routingConfig:        &sharedrouter.RoutingConfig{},
+		makeRoutedEvaluator: func(modelName string) (platform.PlatformEvaluator, error) {
+			return &mockEvaluator{signature: makeSig, modelName: modelName}, nil
+		},
+		unloadGauge: routerModelUnloadGauge.WithLabelValues("global_only"),
+	}
+
+	newConfig := &sharedrouter.RoutingConfig{
+		GlobalModelName: "global-only-model",
+	}
+
+	if err := router.applyRouterConfig(ctx, newConfig); err != nil {
+		t.Fatalf("applyRouterConfig returned error: %v", err)
+	}
+
+	if router.globalModel == nil {
+		t.Fatalf("globalModel was not set")
+	}
+
+	if _, ok := router.routingTable["global-only-model"]; !ok {
+		t.Fatalf("routingTable missing global model")
+	}
+
+	if router.ioState == nil || router.ioState.signature == nil {
+		t.Fatalf("router IO signature was not seeded from the global model")
+	}
+
+	var hasScore bool
+	for _, out := range router.ioState.signature.Outputs {
+		if out.Name == "score" {
+			hasScore = true
+		}
+	}
+	if !hasScore {
+		t.Fatalf("router signature missing global model output 'score', got %#v", router.ioState.signature.Outputs)
+	}
+}
+
 func TestRouter_applyRouterConfig_LoadError(t *testing.T) {
 	ctx := context.Background()
 

--- a/service/platform/router/router.go
+++ b/service/platform/router/router.go
@@ -242,7 +242,13 @@ func (r *Router) Predict(ctx context.Context, params []interface{}) ([]interface
 		routerInputOffset := r.ioState.routerInputOffset
 
 		hasFixedEvaluator := r.fixedEvaluator != nil
+		// Prefer the global model name from the live router config (router.yaml)
+		// so the reported inference_model_id reflects the actual global model
+		// artifact. Falls back to the static Output.GlobalModelOverride.
 		reportedGlobalModelName := r.outputConfig.GlobalModelOverride
+		if r.routingConfig != nil && r.routingConfig.GlobalModelName != "" {
+			reportedGlobalModelName = r.routingConfig.GlobalModelName
+		}
 		noModelName := r.outputConfig.NoModelID
 
 		numInputs := len(params)


### PR DESCRIPTION
Seed the router IO signature from the global model ~when the entity
routing table is empty, so a global-only config (entityMapping: [] with
only globalModelName) loads on cold start instead of failing with a nil
signature or a fixed-evaluator field check against no collected outputs.~

Also report the live router.yaml globalModelName as the served model id,
falling back to Output.GlobalModelOverride when unset.

Co-authored-by: Anthropic Claude Opus 4.8 <noreply@anthropic.com>
Co-authored-by: Cursor <cursoragent@cursor.com>