### PR TITLE
fix(service/triton): order ModelInfer outputs by name, not response p…

### DIFF
--- a/service/platform/router/reload_test.go
+++ b/service/platform/router/reload_test.go
@@ -782,6 +782,140 @@ func TestRouter_applyRouterConfig_configuredOutputOrder(t *testing.T) {
 	assert.Equal(t, [][]float32{{1}, {10}}, results[2])
 }
 
+// TestRouter_Predict_ReordersOutputsPerRowAcrossBatches exercises the full
+// Predict reassembly path: rows are interleaved across two models whose internal
+// output orders differ, and every row carries a distinct value. This catches
+// both output-name misordering and per-row/offset mixups in the batched path --
+// neither of which TestRouter_applyRouterConfig_configuredOutputOrder can detect,
+// since it returns the same value for every row of a model's batch.
+func TestRouter_Predict_ReordersOutputsPerRowAcrossBatches(t *testing.T) {
+	for _, forceBatchSize1 := range []bool{false, true} {
+		name := "batched"
+		if forceBatchSize1 {
+			name = "forceBatchSize1"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			mockClient := &mockUnloader{tritonServer: &mockTritonServer{}}
+
+			// distinct value per input token so a row mixup is detectable
+			valueOf := map[string]float32{"a": 10, "b": 20, "c": 30, "d": 40, "e": 50}
+
+			// model1 emits [score, calibration]; model2 emits [calibration, score]
+			model1Sig := func() *domain.Signature {
+				return &domain.Signature{
+					Inputs: []domain.Input{{Name: "text", Index: 0, Type: reflect.TypeOf("")}},
+					Outputs: []domain.Output{
+						{Name: "score", Index: 0, DataType: "float32"},
+						{Name: "calibration", Index: 1, DataType: "float32"},
+					},
+				}
+			}
+			model2Sig := func() *domain.Signature {
+				return &domain.Signature{
+					Inputs: []domain.Input{{Name: "text", Index: 0, Type: reflect.TypeOf("")}},
+					Outputs: []domain.Output{
+						{Name: "calibration", Index: 0, DataType: "float32"},
+						{Name: "score", Index: 1, DataType: "float32"},
+					},
+				}
+			}
+
+			// compute per-row outputs from the input token, in the evaluator's
+			// own signature output order
+			perRowPredict := func(params []interface{}, signature *domain.Signature) ([]interface{}, error) {
+				texts := params[0].([][]string)
+				bs := len(texts)
+				outputs := make([]interface{}, len(signature.Outputs))
+				for i, out := range signature.Outputs {
+					batch := make([][]float32, bs)
+					for j := range batch {
+						base := valueOf[texts[j][0]]
+						switch out.Name {
+						case "score":
+							batch[j] = []float32{base}
+						case "calibration":
+							batch[j] = []float32{base + 0.5}
+						default:
+							return nil, fmt.Errorf("unexpected output %s", out.Name)
+						}
+					}
+					outputs[i] = batch
+				}
+				return outputs, nil
+			}
+
+			cfg := &config.Model{
+				ID:       "test_reorder_perrow",
+				Debug:    true,
+				Mode:     "router",
+				Platform: "triton",
+				Router: &config.RouterConfig{
+					ConfigURL:       "memory://router-config",
+					InputName:       "router_id",
+					ForceBatchSize1: forceBatchSize1,
+					Global: config.GlobalModelConfig{
+						PredictionReplacements: []config.PredictionReplacement{
+							{Name: "score", Type: "float32", Value: 0.0},
+							{Name: "calibration", Type: "float32", Value: 0.0},
+						},
+					},
+					Output: config.OutputConfig{FieldName: "model_id"},
+				},
+				MetaInput: shared.MetaInput{
+					Outputs: []*shared.Field{
+						{Name: "calibration", DataType: "float32"},
+						{Name: "model_id", DataType: "string"},
+						{Name: "score", DataType: "float32"},
+					},
+				},
+				Triton: &config.TritonConfig{ServerID: "test_server"},
+			}
+			cfg.Init(nil)
+
+			router, err := newRouter(cfg, nil, map[string]UnloadService{
+				"test_server": &triton.Service{Unloader: mockClient},
+			}, func(modelName string) (platform.PlatformEvaluator, error) {
+				switch modelName {
+				case "model1":
+					return &mockEvaluator{modelName: modelName, signature: model1Sig, predictor: perRowPredict, tritonServer: mockClient.tritonServer}, nil
+				case "model2":
+					return &mockEvaluator{modelName: modelName, signature: model2Sig, predictor: perRowPredict, tritonServer: mockClient.tritonServer}, nil
+				default:
+					return nil, errors.New("unexpected model")
+				}
+			})
+			if err != nil {
+				t.Fatalf("newRouter error: %v", err)
+			}
+
+			if err := router.applyRouterConfig(ctx, &sharedrouter.RoutingConfig{
+				EntityMapping: []sharedrouter.EntityKV{
+					{EntityID: 1, ModelName: "model1"},
+					{EntityID: 2, ModelName: "model2"},
+				},
+			}); err != nil {
+				t.Fatalf("applyRouterConfig error: %v", err)
+			}
+
+			// rows routed model1,model2,model1,model2,model1
+			results, err := router.Predict(ctx, []interface{}{
+				[][]string{{"a"}, {"b"}, {"c"}, {"d"}, {"e"}}, // text
+				[][]int64{{1}, {2}, {1}, {2}, {1}},            // router_id
+			})
+			if err != nil {
+				t.Fatalf("Predict error: %v", err)
+			}
+
+			// configured output order is [calibration, model_id, score]
+			assert.Equal(t, [][]float32{{10.5}, {20.5}, {30.5}, {40.5}, {50.5}}, results[0], "calibration column")
+			assert.Equal(t, [][]string{{"model1"}, {"model2"}, {"model1"}, {"model2"}, {"model1"}}, results[1], "model_id column")
+			assert.Equal(t, [][]float32{{10}, {20}, {30}, {40}, {50}}, results[2], "score column")
+		})
+	}
+}
+
 func TestRouter_applyRouterConfig_configuredOutputValidation(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/service/platform/router/router.go
+++ b/service/platform/router/router.go
@@ -414,6 +414,11 @@ func (r *Router) Predict(ctx context.Context, params []interface{}) ([]interface
 					// Rely on downstream for timeouts
 					results, err = b.evaluator.Predict(ctx, orderedInputs)
 
+					// Labeling results positionally by evalSig.Outputs is safe
+					// because the evaluator guarantees Predict returns values in
+					// signature.Outputs order (it maps the name-keyed ModelInfer
+					// response into that order). Do not assume the raw Triton
+					// response order matches metadata. See service/triton doc.go.
 					outputNames = make([]string, len(evalSig.Outputs))
 					for i, out := range evalSig.Outputs {
 						outputNames[i] = out.Name

--- a/service/triton/client.go
+++ b/service/triton/client.go
@@ -18,7 +18,12 @@ type TritonClient interface {
 
 	// inputs is expected to be [numInputs]([batchSize][1]T) (see service/request.Request.Feeds)
 	// inputs will never be empty
-	ModelInfer(ctx context.Context, modelName string, inputs []interface{}, indexToName map[int]string) ([]interface{}, error)
+	//
+	// Returns the output tensors keyed by their Triton output tensor name. Callers
+	// (the evaluator) are responsible for mapping these into signature order; the
+	// map deliberately carries no positional/order information so no consumer can
+	// depend on the order Triton happens to return tensors in.
+	ModelInfer(ctx context.Context, modelName string, inputs []interface{}, indexToName map[int]string) (map[string]interface{}, error)
 
 	ModelReady(ctx context.Context, modelName string) (bool, error)
 

--- a/service/triton/doc.go
+++ b/service/triton/doc.go
@@ -1,5 +1,3 @@
-package triton
-
 /*
 Package triton integrates mly with a Triton Inference Server over the
 KServe/Open-Inference v2 protocol (gRPC preferred; the HTTP client is deprecated).
@@ -31,3 +29,4 @@ assume the raw ModelInfer response order matches metadata. When outputs share a
 datatype (e.g. two FP32 scalars), a positional mismatch is otherwise silently
 undetectable: values are mislabeled with no type error.
 */
+package triton

--- a/service/triton/doc.go
+++ b/service/triton/doc.go
@@ -1,0 +1,33 @@
+package triton
+
+/*
+Package triton integrates mly with a Triton Inference Server over the
+KServe/Open-Inference v2 protocol (gRPC preferred; the HTTP client is deprecated).
+
+# Output ordering contract
+
+The v2 protocol does not guarantee that the order of tensors in a ModelInfer
+response matches the order of outputs reported by ModelMetadata. The only
+response-side ordering guarantee is that raw_output_contents[i] aligns with
+outputs[i]; the outputs list itself may be emitted in any order. In practice,
+models exported with non-deterministic tensor ordering can return inference
+outputs in a different order than their own metadata declares.
+
+Because every response tensor carries its own name, outputs are addressed by
+name rather than by position:
+
+  - TritonClient.ModelInfer returns outputs as map[string]interface{} keyed by
+    the Triton output tensor name. The map deliberately carries no ordering, so
+    no caller can depend on the order Triton happened to return tensors in.
+
+  - TritonEvaluator.Predict is the single place that establishes order: it maps
+    the named results into signature.Outputs order (the order captured from
+    ModelMetadata at reload) and returns a []interface{} that satisfies the
+    platform.Predictor contract result[i] == signature.Outputs[i].
+
+Consumers — including the router, which reassembles outputs from multiple models
+into one response — must rely on this evaluator-established order and must not
+assume the raw ModelInfer response order matches metadata. When outputs share a
+datatype (e.g. two FP32 scalars), a positional mismatch is otherwise silently
+undetectable: values are mislabeled with no type error.
+*/

--- a/service/triton/evaluator.go
+++ b/service/triton/evaluator.go
@@ -126,10 +126,19 @@ func (t *TritonEvaluator) registerUsage() error {
 	return nil
 }
 
-// Predict performs inference via Triton Inference Server
+// Predict performs inference via Triton Inference Server.
+//
+// The client returns output tensors keyed by name. We map them into
+// signature.Outputs order so callers can rely on result[i] == signature.Outputs[i]
+// regardless of the order Triton emitted tensors in the response.
 func (t *TritonEvaluator) Predict(ctx context.Context, params []interface{}) ([]interface{}, error) {
 	if len(params) == 0 {
 		return nil, fmt.Errorf("no input parameters")
+	}
+
+	sig := t.signature
+	if sig == nil {
+		return nil, fmt.Errorf("model %s: Predict called before signature was loaded", t.modelName)
 	}
 
 	requestCtx := ctx
@@ -139,7 +148,26 @@ func (t *TritonEvaluator) Predict(ctx context.Context, params []interface{}) ([]
 		defer cancel()
 	}
 
-	return t.service.Client.ModelInfer(requestCtx, t.modelName, params, t.indexToName)
+	resultsByName, err := t.service.Client.ModelInfer(requestCtx, t.modelName, params, t.indexToName)
+	if err != nil {
+		return nil, err
+	}
+
+	ordered := make([]interface{}, len(sig.Outputs))
+	for i, out := range sig.Outputs {
+		value, ok := resultsByName[out.Name]
+		if !ok {
+			return nil, fmt.Errorf("model %s response missing output %q", t.modelName, out.Name)
+		}
+		ordered[i] = value
+	}
+
+	if len(resultsByName) != len(sig.Outputs) {
+		return nil, fmt.Errorf("model %s returned %d outputs, signature expects %d",
+			t.modelName, len(resultsByName), len(sig.Outputs))
+	}
+
+	return ordered, nil
 }
 
 func (t *TritonEvaluator) Signature() *domain.Signature {
@@ -262,7 +290,7 @@ func (t *TritonEvaluator) ReloadIfNeeded(ctx context.Context) error {
 	for i, output := range metadata.Outputs {
 		o := domain.Output{
 			Name:  output.Name,
-			Index: len(outputs),
+			Index: i,
 		}
 
 		goType := TritonToGoType(output.Datatype)

--- a/service/triton/evaluator_test.go
+++ b/service/triton/evaluator_test.go
@@ -20,12 +20,16 @@ type mockTritonClient struct {
 	modelLoadErr map[string]error
 
 	metadata *ModelMetadata
+
+	// inferResult, when non-nil, is returned by ModelInfer keyed by output name.
+	inferResult map[string]interface{}
+	inferErr    error
 }
 
 func (m *mockTritonClient) ServerReady(ctx context.Context) error { return nil }
 
-func (m *mockTritonClient) ModelInfer(ctx context.Context, modelName string, inputs []interface{}, indexToName map[int]string) ([]interface{}, error) {
-	return nil, nil
+func (m *mockTritonClient) ModelInfer(ctx context.Context, modelName string, inputs []interface{}, indexToName map[int]string) (map[string]interface{}, error) {
+	return m.inferResult, m.inferErr
 }
 
 func (m *mockTritonClient) ModelReady(ctx context.Context, modelName string) (bool, error) {
@@ -203,4 +207,75 @@ func TestTritonEvaluator_PredictEmptyBatch(t *testing.T) {
 	_, err := evaluator.Predict(context.Background(), []interface{}{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no input parameters")
+}
+
+// TestTritonEvaluator_PredictOrdersOutputsByName guards the core invariant of the
+// name-keyed ModelInfer contract: the client returns outputs keyed by name (no
+// order), and Predict must place them into signature.Outputs order. The map is
+// deliberately built so its keys do not align positionally with the signature.
+func TestTritonEvaluator_PredictOrdersOutputsByName(t *testing.T) {
+	cfg := &config.Model{
+		ID: "test_model",
+		Triton: &config.TritonConfig{
+			ModelName: "test_model",
+		},
+	}
+
+	mock := &mockTritonClient{
+		metadata: &ModelMetadata{
+			Inputs: []MetadataTensor{
+				{Name: "input1", Datatype: "FP32"},
+			},
+			// signature output order is [score, calibration]
+			Outputs: []MetadataTensor{
+				{Name: "score", Datatype: "FP32"},
+				{Name: "calibration", Datatype: "FP32"},
+			},
+		},
+		inferResult: map[string]interface{}{
+			"calibration": [][]float32{{0.25}},
+			"score":       [][]float32{{0.90}},
+		},
+	}
+
+	evaluator := newTritonEvaluator(cfg, mock)
+	defer evaluator.Close()
+
+	sig := evaluator.Signature()
+	require.NotNil(t, sig)
+	require.Equal(t, "score", sig.Outputs[0].Name)
+	require.Equal(t, "calibration", sig.Outputs[1].Name)
+
+	results, err := evaluator.Predict(context.Background(), []interface{}{[][]float32{{1.0}}})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	assert.Equal(t, [][]float32{{0.90}}, results[0], "index 0 must be score, per signature order")
+	assert.Equal(t, [][]float32{{0.25}}, results[1], "index 1 must be calibration, per signature order")
+}
+
+func TestTritonEvaluator_PredictMissingOutput(t *testing.T) {
+	cfg := &config.Model{
+		ID: "test_model",
+		Triton: &config.TritonConfig{
+			ModelName: "test_model",
+		},
+	}
+
+	mock := &mockTritonClient{
+		metadata: &ModelMetadata{
+			Inputs:  []MetadataTensor{{Name: "input1", Datatype: "FP32"}},
+			Outputs: []MetadataTensor{{Name: "score", Datatype: "FP32"}, {Name: "calibration", Datatype: "FP32"}},
+		},
+		inferResult: map[string]interface{}{
+			"score": [][]float32{{0.90}},
+		},
+	}
+
+	evaluator := newTritonEvaluator(cfg, mock)
+	defer evaluator.Close()
+
+	_, err := evaluator.Predict(context.Background(), []interface{}{[][]float32{{1.0}}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing output")
 }

--- a/service/triton/grpc.go
+++ b/service/triton/grpc.go
@@ -29,7 +29,7 @@ func (c *GRPCClient) ServerReady(ctx context.Context) error {
 	return err
 }
 
-func (c *GRPCClient) ModelInfer(ctx context.Context, modelName string, inputs []interface{}, indexToName map[int]string) ([]interface{}, error) {
+func (c *GRPCClient) ModelInfer(ctx context.Context, modelName string, inputs []interface{}, indexToName map[int]string) (map[string]interface{}, error) {
 	grpcRequest, err := toGRPCRequest(modelName, inputs, indexToName)
 	if err != nil {
 		return nil, err
@@ -40,12 +40,7 @@ func (c *GRPCClient) ModelInfer(ctx context.Context, modelName string, inputs []
 		return nil, err
 	}
 
-	result, err := convertGRPCResponse(grpcResponse)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return convertGRPCResponse(grpcResponse)
 }
 
 func (c *GRPCClient) ModelReady(ctx context.Context, modelName string) (bool, error) {
@@ -290,12 +285,15 @@ func parseRawOutput(rawData []byte, datatype string, batchSize int) (interface{}
 	}
 }
 
-func convertGRPCResponse(response *triton.ModelInferResponse) ([]interface{}, error) {
+// convertGRPCResponse maps the response tensors into a map keyed by output name.
+// Ordering into signature order is the evaluator's responsibility; keying by name
+// here removes any reliance on the order Triton returns tensors in.
+func convertGRPCResponse(response *triton.ModelInferResponse) (map[string]interface{}, error) {
 	if len(response.Outputs) == 0 {
 		return nil, fmt.Errorf("no outputs in response")
 	}
 
-	result := make([]interface{}, len(response.Outputs))
+	result := make(map[string]interface{}, len(response.Outputs))
 	useRawContents := len(response.RawOutputContents) > 0
 
 	for i, output := range response.Outputs {
@@ -303,6 +301,8 @@ func convertGRPCResponse(response *triton.ModelInferResponse) ([]interface{}, er
 		if len(output.Shape) > 0 {
 			batchSize = int(output.Shape[0])
 		}
+
+		var parsed interface{}
 
 		if useRawContents {
 			if i >= len(response.RawOutputContents) {
@@ -313,51 +313,55 @@ func convertGRPCResponse(response *triton.ModelInferResponse) ([]interface{}, er
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse raw output %s: %w", output.Name, err)
 			}
-			result[i] = parsedData
-			continue
+			parsed = parsedData
+		} else {
+			if output.Contents == nil {
+				return nil, fmt.Errorf("output %s missing contents", output.Name)
+			}
+
+			switch output.Datatype {
+			case "FP32":
+				converted := make([][]float32, batchSize)
+				for j := 0; j < batchSize && j < len(output.Contents.Fp32Contents); j++ {
+					converted[j] = []float32{output.Contents.Fp32Contents[j]}
+				}
+				parsed = converted
+			case "FP64":
+				converted := make([][]float64, batchSize)
+				for j := 0; j < batchSize && j < len(output.Contents.Fp64Contents); j++ {
+					converted[j] = []float64{output.Contents.Fp64Contents[j]}
+				}
+				parsed = converted
+
+			case "INT32":
+				converted := make([][]int32, batchSize)
+				for j := 0; j < batchSize && j < len(output.Contents.IntContents); j++ {
+					converted[j] = []int32{output.Contents.IntContents[j]}
+				}
+				parsed = converted
+			case "INT64":
+				converted := make([][]int64, batchSize)
+				for j := 0; j < batchSize && j < len(output.Contents.Int64Contents); j++ {
+					converted[j] = []int64{output.Contents.Int64Contents[j]}
+				}
+				parsed = converted
+
+			case "BYTES":
+				converted := make([][]string, batchSize)
+				for j := 0; j < batchSize && j < len(output.Contents.BytesContents); j++ {
+					converted[j] = []string{string(output.Contents.BytesContents[j])}
+				}
+				parsed = converted
+
+			default:
+				return nil, fmt.Errorf("unsupported output datatype %s for %s", output.Datatype, output.Name)
+			}
 		}
 
-		if output.Contents == nil {
-			return nil, fmt.Errorf("output %s missing contents", output.Name)
+		if _, dup := result[output.Name]; dup {
+			return nil, fmt.Errorf("duplicate output name %q in response", output.Name)
 		}
-
-		switch output.Datatype {
-		case "FP32":
-			converted := make([][]float32, batchSize)
-			for j := 0; j < batchSize && j < len(output.Contents.Fp32Contents); j++ {
-				converted[j] = []float32{output.Contents.Fp32Contents[j]}
-			}
-			result[i] = converted
-		case "FP64":
-			converted := make([][]float64, batchSize)
-			for j := 0; j < batchSize && j < len(output.Contents.Fp64Contents); j++ {
-				converted[j] = []float64{output.Contents.Fp64Contents[j]}
-			}
-			result[i] = converted
-
-		case "INT32":
-			converted := make([][]int32, batchSize)
-			for j := 0; j < batchSize && j < len(output.Contents.IntContents); j++ {
-				converted[j] = []int32{output.Contents.IntContents[j]}
-			}
-			result[i] = converted
-		case "INT64":
-			converted := make([][]int64, batchSize)
-			for j := 0; j < batchSize && j < len(output.Contents.Int64Contents); j++ {
-				converted[j] = []int64{output.Contents.Int64Contents[j]}
-			}
-			result[i] = converted
-
-		case "BYTES":
-			converted := make([][]string, batchSize)
-			for j := 0; j < batchSize && j < len(output.Contents.BytesContents); j++ {
-				converted[j] = []string{string(output.Contents.BytesContents[j])}
-			}
-			result[i] = converted
-
-		default:
-			return nil, fmt.Errorf("unsupported output datatype %s for %s", output.Datatype, output.Name)
-		}
+		result[output.Name] = parsed
 	}
 
 	return result, nil

--- a/service/triton/grpc_test.go
+++ b/service/triton/grpc_test.go
@@ -145,8 +145,8 @@ func TestGRPCClient_ModelInfer(t *testing.T) {
 	require.Len(t, results, 1)
 
 	// Verify output format
-	output, ok := results[0].([][]int64)
-	require.True(t, ok, "expected [][]int64, got %T", results[0])
+	output, ok := results["output"].([][]int64)
+	require.True(t, ok, "expected [][]int64, got %T", results["output"])
 	require.Len(t, output, 2)
 	assert.Equal(t, []int64{42}, output[0])
 	assert.Equal(t, []int64{100}, output[1])
@@ -186,8 +186,8 @@ func TestGRPCClient_ModelInferWithRawOutputContents(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
-	output, ok := results[0].([][]float32)
-	require.True(t, ok, "expected [][]float32, got %T", results[0])
+	output, ok := results["output"].([][]float32)
+	require.True(t, ok, "expected [][]float32, got %T", results["output"])
 	require.Len(t, output, 2)
 	assert.InDelta(t, 10.0, output[0][0], 0.01)
 	assert.InDelta(t, 50.0, output[1][0], 0.01)
@@ -294,7 +294,7 @@ func TestGRPCClient_ModelInferAllInputTypes(t *testing.T) {
 			results, err := client.ModelInfer(ctx, "test_model", []interface{}{tc.inputData}, map[int]string{0: "input1"})
 			require.NoError(t, err)
 			require.Len(t, results, 1)
-			assert.NotNil(t, results[0])
+			assert.NotNil(t, results["output"])
 		})
 	}
 }
@@ -332,8 +332,8 @@ func TestGRPCClient_ModelInferBytesOutput(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 
-	output, ok := results[0].([][]string)
-	require.True(t, ok, "expected [][]string, got %T", results[0])
+	output, ok := results["output"].([][]string)
+	require.True(t, ok, "expected [][]string, got %T", results["output"])
 	require.Len(t, output, 2)
 	assert.Equal(t, []string{"result1"}, output[0])
 	assert.Equal(t, []string{"result2"}, output[1])
@@ -392,8 +392,8 @@ func TestGRPCClient_ModelInferDifferentBatchSizes(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, results, 1)
 
-			output, ok := results[0].([][]int64)
-			require.True(t, ok, "expected [][]int64, got %T", results[0])
+			output, ok := results["output"].([][]int64)
+			require.True(t, ok, "expected [][]int64, got %T", results["output"])
 			assert.Len(t, output, tc.batchSize)
 		})
 	}
@@ -464,4 +464,58 @@ func TestGRPCClient_ModelInferMissingOutput(t *testing.T) {
 	_, err := client.ModelInfer(ctx, "test_model", params, map[int]string{0: "input1"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing contents")
+}
+
+// TestConvertGRPCResponse_KeysByName ensures each response tensor is keyed by its
+// own wire name, so a response whose tensor order differs from the model's
+// metadata order still maps values to the correct names (no positional aliasing).
+func TestConvertGRPCResponse_KeysByName(t *testing.T) {
+	response := &triton.ModelInferResponse{
+		ModelName: "test_model",
+		Outputs: []*triton.ModelInferResponse_InferOutputTensor{
+			{
+				Name:     "calibration",
+				Datatype: "FP32",
+				Shape:    []int64{1, 1},
+				Contents: &triton.InferTensorContents{Fp32Contents: []float32{0.25}},
+			},
+			{
+				Name:     "score",
+				Datatype: "FP32",
+				Shape:    []int64{1, 1},
+				Contents: &triton.InferTensorContents{Fp32Contents: []float32{0.90}},
+			},
+		},
+	}
+
+	result, err := convertGRPCResponse(response)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	assert.Equal(t, [][]float32{{0.25}}, result["calibration"])
+	assert.Equal(t, [][]float32{{0.90}}, result["score"])
+}
+
+func TestConvertGRPCResponse_DuplicateName(t *testing.T) {
+	response := &triton.ModelInferResponse{
+		ModelName: "test_model",
+		Outputs: []*triton.ModelInferResponse_InferOutputTensor{
+			{
+				Name:     "score",
+				Datatype: "FP32",
+				Shape:    []int64{1, 1},
+				Contents: &triton.InferTensorContents{Fp32Contents: []float32{0.25}},
+			},
+			{
+				Name:     "score",
+				Datatype: "FP32",
+				Shape:    []int64{1, 1},
+				Contents: &triton.InferTensorContents{Fp32Contents: []float32{0.90}},
+			},
+		},
+	}
+
+	_, err := convertGRPCResponse(response)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate output name")
 }

--- a/service/triton/grpc_test.go
+++ b/service/triton/grpc_test.go
@@ -72,8 +72,12 @@ func startMockGRPCServer(t *testing.T, mock *mockTritonServer) (*grpc.Server, *b
 	triton.RegisterGRPCInferenceServiceServer(server, mock)
 
 	go func() {
+		// Serve returns nil once server.Stop() is called during teardown; a
+		// non-nil error means startup failed. Use Errorf, not Fatalf: Fatalf
+		// calls runtime.Goexit on this goroutine (not the test goroutine), so
+		// it cannot fail the test and can panic if it fires after completion.
 		if err := server.Serve(listener); err != nil {
-			t.Fatalf("Server exited with error: %v", err)
+			t.Errorf("Server exited with error: %v", err)
 		}
 	}()
 

--- a/service/triton/http.go
+++ b/service/triton/http.go
@@ -28,7 +28,7 @@ func (c *HTTPClient) ServerReady(ctx context.Context) error {
 	return err
 }
 
-func (c *HTTPClient) ModelInfer(ctx context.Context, modelName string, inputs []interface{}, indexToName map[int]string) ([]interface{}, error) {
+func (c *HTTPClient) ModelInfer(ctx context.Context, modelName string, inputs []interface{}, indexToName map[int]string) (map[string]interface{}, error) {
 	tritonRequest, err := convertToTritonRequest(inputs, indexToName)
 	if err != nil {
 		return nil, err
@@ -368,25 +368,32 @@ func convertToTritonRequest(params []interface{}, indexToName map[int]string) (*
 	return &TritonRequest{Inputs: inputs}, nil
 }
 
-// convertFromTritonResponse converts Triton response to [numOutputs]([batchSize]D_T) - shape depends on model output.
-func convertFromTritonResponse(response *TritonResponse) ([]interface{}, error) {
-	var result []interface{}
+// convertFromTritonResponse maps the Triton response into output tensors keyed by
+// name; each value is [batchSize][1]float32. Ordering into signature order is the
+// evaluator's responsibility.
+func convertFromTritonResponse(response *TritonResponse) (map[string]interface{}, error) {
+	result := make(map[string]interface{}, len(response.Outputs))
 
 	for outputOffset, output := range response.Outputs {
-		if data, ok := output.Data.([]interface{}); ok && len(data) > 0 {
-			batchSize := len(data)
-			converted := make([][]float32, batchSize)
-			for i, v := range data {
-				if f, ok := v.(float64); ok {
-					converted[i] = []float32{float32(f)}
-				} else {
-					return nil, fmt.Errorf("unsupported output type for %s: %T, for batch item %d of output offset %d", output.Name, v, i, outputOffset)
-				}
-			}
-			result = append(result, converted)
-		} else {
+		data, ok := output.Data.([]interface{})
+		if !ok || len(data) == 0 {
 			return nil, fmt.Errorf("unsupported output type for %s: %T, for output offset %d", output.Name, output.Data, outputOffset)
 		}
+
+		batchSize := len(data)
+		converted := make([][]float32, batchSize)
+		for i, v := range data {
+			f, ok := v.(float64)
+			if !ok {
+				return nil, fmt.Errorf("unsupported output type for %s: %T, for batch item %d of output offset %d", output.Name, v, i, outputOffset)
+			}
+			converted[i] = []float32{float32(f)}
+		}
+
+		if _, dup := result[output.Name]; dup {
+			return nil, fmt.Errorf("duplicate output name %q in response", output.Name)
+		}
+		result[output.Name] = converted
 	}
 
 	return result, nil

--- a/service/triton/metrics.go
+++ b/service/triton/metrics.go
@@ -124,8 +124,8 @@ func withGatherers(fn func() error, fnObserve func(float64)) error {
 	return nil
 }
 
-func (c *MeteredTritonClient) ModelInfer(ctx context.Context, modelName string, inputs []interface{}, indexToName map[int]string) ([]interface{}, error) {
-	var result []interface{}
+func (c *MeteredTritonClient) ModelInfer(ctx context.Context, modelName string, inputs []interface{}, indexToName map[int]string) (map[string]interface{}, error) {
+	var result map[string]interface{}
 	var err error
 
 	err = withGatherers(func() error {

--- a/third_party/TRITON.md
+++ b/third_party/TRITON.md
@@ -6,6 +6,18 @@ Generated proto files are **committed to the repository** for build reliability.
 
 Triton uses `raw_output_contents` for performance (binary format vs. structured).
 
+# Output Tensor Ordering
+
+The KServe/Triton v2 protocol only guarantees that `raw_output_contents[i]`
+aligns with `outputs[i]` in a `ModelInfer` response. It does **not** guarantee
+that the `outputs` order matches the order reported by `ModelMetadata` — a model
+whose metadata lists `[a, b]` may return inference outputs as `[b, a]`. Every
+response tensor carries its own `name`, so mly addresses outputs by name: the
+client returns outputs keyed by tensor name and `TritonEvaluator.Predict`
+reorders them into signature order (see the `service/triton` package doc). Do
+not reintroduce positional handling of response tensors — when two outputs share
+a datatype, a positional mismatch mislabels values with no error.
+
 # When to Regenerate Proto Files
 
 Regenerate only when:


### PR DESCRIPTION
Empirical testing shows that the Triton metadata endpoint will provide outputs in any arbitrary order, which may or may not correspond to the ordering of the actual inference endpoint ordering (which seems to be consistent).
This changes the logic such that now Triton inference response outputs are ordered correctly for `service.triton.TritonEvaluator`.